### PR TITLE
OOP in Kotlin examples with Shapes

### DIFF
--- a/kotlin/src/main/kotlin/tyler/shapes/Circle.kt
+++ b/kotlin/src/main/kotlin/tyler/shapes/Circle.kt
@@ -1,0 +1,13 @@
+package tyler.shapes
+
+import kotlin.math.pow
+
+class Circle(
+    val radius: Double,
+) : Shape() {
+
+    fun computeDiameter(): Double = radius * 2.0
+
+    override fun computeArea(): Double = Math.PI * radius.pow(x = 2.0)
+    override fun describe() = "This is a Circle. It has an area of ${computeArea()} and a radius of $radius."
+}

--- a/kotlin/src/main/kotlin/tyler/shapes/Shape.kt
+++ b/kotlin/src/main/kotlin/tyler/shapes/Shape.kt
@@ -4,8 +4,16 @@ abstract class Shape {
     abstract fun computeArea(): Double
 
     open fun describe() = SHAPE_DEFAULT_DESCRIPTION.format(computeArea())
+
+    /*
+     Every class in Kotlin, C#, everything has a toString function.
+     When you print or Console.WriteLine that class, it looks at the toString function.
+     If you override toString, it uses the override instead.
+     */
+    override fun toString(): String = SHAPE_TO_STRING_OVERRIDE
 }
 
 //region Constants
 const val SHAPE_DEFAULT_DESCRIPTION = "This is a Shape. It has an area of %f."
+const val SHAPE_TO_STRING_OVERRIDE = "Overridden print statement."
 //endregion Constants

--- a/kotlin/src/main/kotlin/tyler/shapes/Shape.kt
+++ b/kotlin/src/main/kotlin/tyler/shapes/Shape.kt
@@ -1,0 +1,11 @@
+package tyler.shapes
+
+abstract class Shape {
+    abstract fun computeArea(): Double
+
+    open fun describe() = SHAPE_DEFAULT_DESCRIPTION.format(computeArea())
+}
+
+//region Constants
+const val SHAPE_DEFAULT_DESCRIPTION = "This is a Shape. It has an area of %f."
+//endregion Constants

--- a/kotlin/src/main/kotlin/tyler/shapes/Square.kt
+++ b/kotlin/src/main/kotlin/tyler/shapes/Square.kt
@@ -1,0 +1,13 @@
+package tyler.shapes
+
+import kotlin.math.pow
+
+class Square(
+    sideLength: Double,
+) : Shape() {
+
+    val width = sideLength
+    val height = sideLength
+
+    override fun computeArea(): Double = width * height
+}

--- a/kotlin/src/test/kotlin/tyler/shapes/ShapesTest.kt
+++ b/kotlin/src/test/kotlin/tyler/shapes/ShapesTest.kt
@@ -1,0 +1,63 @@
+package tyler.shapes
+
+import org.junit.jupiter.api.Test
+import kotlin.math.pow
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+
+class ShapesTest {
+    @Test
+    fun `a Circle IS a Shape AND a Circle`() {
+        val circle = Circle(radius = 1.0)
+
+        // A circle is both a Circle and a Shape
+        assertTrue(actual = circle is Circle)
+        assertTrue(actual = circle is Shape)
+
+        // A circle is not a Square
+        assertFalse(actual = circle is Square)
+    }
+
+    @Test
+    fun `describing a Square uses the default description because it is NOT overridden`() {
+        val square = Square(sideLength = 1.0)
+
+        val actualDescription = square.describe()
+        val expectedDescription = SHAPE_DEFAULT_DESCRIPTION.format(square.computeArea())
+
+        assertEquals(expectedDescription, actualDescription)
+    }
+
+    @Test
+    fun `describing a Circle DOES NOT use the default description because it IS overridden`() {
+        val circle = Circle(radius = 1.0)
+
+        val actualDescription = circle.describe()
+        val expectedDescription = "This is a Circle. It has an area of ${circle.computeArea()} and a radius of ${circle.radius}."
+        val expectedDescriptionIfNotOverridden = SHAPE_DEFAULT_DESCRIPTION.format(circle.computeArea())
+
+        assertEquals(expectedDescription, actualDescription)
+        assertNotEquals(expectedDescriptionIfNotOverridden, actualDescription)
+    }
+
+    @Test
+    fun `area calculates as expected for a Square`() {
+        val square = Square(sideLength = 2.0)
+        val actualArea = square.computeArea()
+        val expectedArea = 2.0 * 2.0
+
+        assertEquals(expectedArea, actualArea)
+    }
+
+    @Test
+    fun `area calculates as expected for a Circle`() {
+        val circle = Circle(radius = 2.0)
+        val actualArea = circle.computeArea()
+        val expectedArea = Math.PI * (2.0).pow(x = 2.0)
+
+        assertEquals(expectedArea, actualArea)
+    }
+}

--- a/kotlin/src/test/kotlin/tyler/shapes/ShapesTest.kt
+++ b/kotlin/src/test/kotlin/tyler/shapes/ShapesTest.kt
@@ -1,6 +1,7 @@
 package tyler.shapes
 
 import org.junit.jupiter.api.Test
+import kotlin.math.exp
 import kotlin.math.pow
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -59,5 +60,19 @@ class ShapesTest {
         val expectedArea = Math.PI * (2.0).pow(x = 2.0)
 
         assertEquals(expectedArea, actualArea)
+    }
+
+    @Test
+    fun `toString returns the overridden string`() {
+        val circle = Circle(radius = 1.0)
+        val square = Square(sideLength = 2.0)
+
+        val expectedString = SHAPE_TO_STRING_OVERRIDE
+
+        val actualStringCircle = circle.toString()
+        val actualStringSquare = square.toString()
+
+        assertEquals(expectedString, actualStringSquare)
+        assertEquals(expectedString, actualStringCircle)
     }
 }


### PR DESCRIPTION
This commit introduces a simple example of object oriented programming.

The parent class is simply Shape. Shape is so simple that it isn't possible to make a Shape without more information, that is why we call it "abstract". It has two subclasses: Circle and Square. Circle and Square are both real classes - we would call them "concrete".

Shape has two functions, one which MUST be overridden: `computeArea`, and another which MAY be overridden: `describe`.

Circle overrides both, and Square only overrides `computeArea`.

This commit also includes Unit Tests that may be read to help understand how this works.